### PR TITLE
remove output name dependency

### DIFF
--- a/plugins/L1TrackClassifier.cc
+++ b/plugins/L1TrackClassifier.cc
@@ -32,7 +32,6 @@
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
 
-
 using namespace std;
 
 
@@ -123,13 +122,10 @@ trackToken(consumes< std::vector<TTTrack< Ref_Phase2TrackerDigi_> > > (iConfig.g
     if ((algorithm == "GBDT") | (algorithm == "All")){
       ONNX_path = edm::FileInPath(iConfig.getParameter<string>("GBDTIdONNXmodel")).fullPath();
       ortinput_names.push_back(iConfig.getParameter<string>("GBDTIdONNXInputName"));
-      //ortoutput_names.push_back(iConfig.getParameter<string>("GBDTIdONNXOutputName"));
-
     }
     if (algorithm == "NN") {
       ONNX_path = edm::FileInPath(iConfig.getParameter<string>("NNIdONNXmodel")).fullPath();
       ortinput_names.push_back(iConfig.getParameter<string>("NNIdONNXInputName"));
-      ortoutput_names.push_back(iConfig.getParameter<string>("NNIdONNXOutputName"));
     }
     cout << "loading fake ID onnx model from " << ONNX_path << std::endl;
   
@@ -199,6 +195,7 @@ void L1TrackClassifier::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
       // batch_size 1 as only one set of transformed features is being processed
       int batch_size = 1;
       // Run classification on a batch of 1
+      ortoutput_names = Runtime.getOutputNames();
       ortoutputs = Runtime.run(ortinput_names,ortinput,ortoutput_names,batch_size); 
       // access first value of nested vector
       if (algorithm == "NN"){

--- a/python/Classifier_cff.py
+++ b/python/Classifier_cff.py
@@ -6,11 +6,9 @@ TrackClassifier = cms.EDProducer("L1TrackClassifier",
 
                                   NNIdONNXmodel = cms.string("L1Trigger/TrackQuality/data/FakeIDNN/NN_model.onnx"),
                                   NNIdONNXInputName = cms.string("input_1"),
-                                  NNIdONNXOutputName = cms.string("Sigmoid_Output_Layer"),
 
                                   GBDTIdONNXmodel = cms.string("L1Trigger/TrackQuality/data/FakeIDGBDT/GBDT_model.onnx"),
                                   GBDTIdONNXInputName = cms.string("feature_input"),
-                                  GBDTIdONNXOutputName = cms.string("prediction"),
 
                                   in_features = cms.vstring(["log_chi2","log_bendchi2","log_chi2rphi","log_chi2rz",
                                                              "nstubs","lay1_hits","lay2_hits","lay3_hits","lay4_hits",


### PR DESCRIPTION
Takes out output name dependency and replaces it with runtime function getOutputNames() found here: https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/ONNXRuntime/src/ONNXRuntime.cc#L153